### PR TITLE
Jm/add brightcove lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ export default class App extends Component {
 | onEnterFullscreen      | Function |   | ✅ | ✅ | Indicates the player enters full screen                                         |                              |
 | onExitFullscreen       | Function |   | ✅ | ✅ | Indicates the player exit full screen                                           |                              |
 | resizeAspectFill       | boolean  | true  | ✅ | ❌ | Specifies that the player should preserve the video’s aspect ratio and fill the layer’s bounds. See: [AVFoundation > AVPlayerLayer > videoGravity ](https://developer.apple.com/documentation/avfoundation/avplayerlayer/1388915-videogravity?language=objc) | |
+| onStatusEvent          | Function |   | ✅ | ✅ | Indicates playback status event has fired                                      | `{ info: string, error?: string }` |
 
 | Method                                | Description                       |
 | ------------------------------------- | --------------------------------- |

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -32,6 +32,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onUpdateBufferProgress;
 @property (nonatomic, copy) RCTDirectEventBlock onEnterFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
+@property (nonatomic, copy) RCTDirectEventBlock onStatusEvent;
 
 -(void) seekTo:(NSNumber *)time;
 

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -187,7 +187,7 @@ BOOL _resizeAspectFill;
             
             self.onStatusEvent(@{
                                  @"type": @("fail"),
-                                 @"error":  error
+                                 @"error":  [error length] != 0 ? error : [NSNull null]
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFailedToPlayToEndTime) {
@@ -199,7 +199,7 @@ BOOL _resizeAspectFill;
             
             self.onStatusEvent(@{
                                  @"type": @("failedToPlayToEndTime"),
-                                 @"error":  error
+                                 @"error":  [error length] != 0 ? error : [NSNull null]
                                  });
         }
     }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeBegin) {
@@ -260,7 +260,7 @@ BOOL _resizeAspectFill;
             
             self.onStatusEvent(@{
                                  @"type": @("error"),
-                                 @"error":  error
+                                  @"error":  [error length] != 0 ? error : [NSNull null]
                                  });
         }
     }

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -55,6 +55,13 @@ BOOL _resizeAspectFill;
         [_playbackService findVideoWithReferenceID:_referenceId parameters:nil completion:^(BCOVVideo *video, NSDictionary *jsonResponse, NSError *error) {
             if (video) {
                 [self.playbackController setVideos: @[ video ]];
+            }  else {
+                if (self.onStatusEvent) {
+                    self.onStatusEvent(@{
+                                         @"type": @("loadFail"),
+                                         @"error": [NSString stringWithFormat:@"Could not find video with referenceId: %@",  _referenceId]
+                                         });
+                }
             }
         }];
     }

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -46,7 +46,7 @@ BOOL _resizeAspectFill;
                 if (self.onStatusEvent) {
                     self.onStatusEvent(@{
                                          @"type": @("loadFail"),
-                                         @"error": [NSString stringWithFormat:@"Could not find video with videoId: %@",  _videoId]
+                                         @"error": [NSString stringWithFormat:@"Could not find video with videoId: %@ with error: `%@`",  _videoId, error]
                                          });
                 }
             }
@@ -59,7 +59,7 @@ BOOL _resizeAspectFill;
                 if (self.onStatusEvent) {
                     self.onStatusEvent(@{
                                          @"type": @("loadFail"),
-                                         @"error": [NSString stringWithFormat:@"Could not find video with referenceId: %@",  _referenceId]
+                                         @"error": [NSString stringWithFormat:@"Could not find video with referenceId: %@ with error: `%@`",  _referenceId, error]
                                          });
                 }
             }
@@ -145,7 +145,7 @@ BOOL _resizeAspectFill;
         }
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playbackReady")
+                                 @"type": @("ready")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlay) {
@@ -155,7 +155,7 @@ BOOL _resizeAspectFill;
         }
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playbackPlay")
+                                 @"type": @("play")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPause) {
@@ -165,7 +165,7 @@ BOOL _resizeAspectFill;
         }
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playbackPause")
+                                 @"type": @("pause")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventEnd) {
@@ -174,39 +174,39 @@ BOOL _resizeAspectFill;
         }
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playbackEnd")
+                                 @"type": @("end")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFail) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("loadFail"),
-                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 @"type": @("fail"),
+                                 @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFailedToPlayToEndTime) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
                                  @"type": @("failedToPlayToEndTime"),
-                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
                                  });
         }
     }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeBegin) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("resumeAttemptBegin")
+                                 @"type": @("resumeBegin")
                                  });
         }
     }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeComplete) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("resumeAttemptComplete")
+                                 @"type": @("resumeComplete")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeFail) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("resumeAttemptFail")
+                                 @"type": @("resumeFail")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackStalled) {
@@ -231,20 +231,20 @@ BOOL _resizeAspectFill;
     }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackLikelyToKeepUp) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playbackBufferLikelyToKeepUp")
+                                 @"type": @("playbackLikelyToKeepUp")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventTerminate) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playerTerminated")
+                                 @"type": @("terminate")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventError) {
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
-                                 @"type": @("playerTerminated"),
-                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 @"type": @("error"),
+                                  @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
                                  });
         }
     }

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -154,7 +154,6 @@ BOOL _resizeAspectFill;
             self.onPlay(@{});
         }
         if (self.onStatusEvent) {
-            
             self.onStatusEvent(@{
                                  @"type": @("play")
                                  });

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -42,6 +42,13 @@ BOOL _resizeAspectFill;
         [_playbackService findVideoWithVideoID:_videoId parameters:nil completion:^(BCOVVideo *video, NSDictionary *jsonResponse, NSError *error) {
             if (video) {
                 [self.playbackController setVideos: @[ video ]];
+            }  else {
+                if (self.onStatusEvent) {
+                    self.onStatusEvent(@{
+                                         @"type": @("loadFail"),
+                                         @"error": [NSString stringWithFormat:@"Could not find video with videoId: %@",  _videoId]
+                                         });
+                }
             }
         }];
     } else if (_referenceId) {

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -129,19 +129,109 @@ BOOL _resizeAspectFill;
         if (self.onReady) {
             self.onReady(@{});
         }
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackReady")
+                                 });
+        }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlay) {
         _playing = true;
         if (self.onPlay) {
             self.onPlay(@{});
+        }
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackPlay")
+                                 });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPause) {
         _playing = false;
         if (self.onPause) {
             self.onPause(@{});
         }
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackPause")
+                                 });
+        }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventEnd) {
         if (self.onEnd) {
             self.onEnd(@{});
+        }
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackEnd")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFail) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("loadFail"),
+                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFailedToPlayToEndTime) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("failedToPlayToEndTime"),
+                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 });
+        }
+    }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeBegin) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("resumeAttemptBegin")
+                                 });
+        }
+    }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeComplete) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("resumeAttemptComplete")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeFail) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("resumeAttemptFail")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackStalled) {
+        // name non-standard to avoid conflict with RCTVideo event PlaybackStalled
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackStalled")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackRecovered) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackRecovered")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackBufferEmpty) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackBufferEmpty")
+                                 });
+        }
+    }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlaybackLikelyToKeepUp) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playbackBufferLikelyToKeepUp")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventTerminate) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playerTerminated")
+                                 });
+        }
+    } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventError) {
+        if (self.onStatusEvent) {
+            self.onStatusEvent(@{
+                                 @"type": @("playerTerminated"),
+                                 @"error": lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError]
+                                 });
         }
     }
 }

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -154,6 +154,7 @@ BOOL _resizeAspectFill;
             self.onPlay(@{});
         }
         if (self.onStatusEvent) {
+            
             self.onStatusEvent(@{
                                  @"type": @("play")
                                  });
@@ -179,16 +180,27 @@ BOOL _resizeAspectFill;
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFail) {
         if (self.onStatusEvent) {
+            
+            NSString* error = @"";
+            if ([lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionEventKeyError] != nil ) {
+                error = [NSString stringWithFormat:@"`%@`",  lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError]];
+            }
+            
             self.onStatusEvent(@{
                                  @"type": @("fail"),
-                                 @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
+                                 @"error":  error
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventFailedToPlayToEndTime) {
         if (self.onStatusEvent) {
+            NSString* error = @"";
+            if ([lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionEventKeyError] != nil ) {
+                error = [NSString stringWithFormat:@"`%@`",  lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError]];
+            }
+            
             self.onStatusEvent(@{
                                  @"type": @("failedToPlayToEndTime"),
-                                 @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
+                                 @"error":  error
                                  });
         }
     }  else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventResumeBegin) {
@@ -242,9 +254,14 @@ BOOL _resizeAspectFill;
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventError) {
         if (self.onStatusEvent) {
+            NSString* error = @"";
+            if ([lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionEventKeyError] != nil ) {
+                error = [NSString stringWithFormat:@"`%@`",  lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError]];
+            }
+            
             self.onStatusEvent(@{
                                  @"type": @("error"),
-                                  @"error":  [lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionLifecycleEventError] != nil   ? lifecycleEvent.properties[kBCOVPlaybackSessionLifecycleEventError] :  [NSNull null]
+                                 @"error":  error
                                  });
         }
     }

--- a/ios/BrightcovePlayerManager.m
+++ b/ios/BrightcovePlayerManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(onUpdateBufferProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onEnterFullscreen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onExitFullscreen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(resizeAspectFill, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(onStatusEvent, RCTDirectEventBlock); 
 
 RCT_EXPORT_METHOD(seekTo:(nonnull NSNumber *)reactTag seconds:(nonnull NSNumber *)seconds) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -124,6 +124,7 @@ BrightcovePlayer.propTypes = {
   onUpdateBufferProgress: PropTypes.func,
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
+  resizeAspectFill: PropTypes.bool,
   onStatusEvent: PropTypes.func,
 };
 

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -80,6 +80,10 @@ class BrightcovePlayer extends Component {
               this.props.onExitFullscreen(event.nativeEvent);
           }
         }}
+        onStatusEvent={event =>
+          this.props.onStatusEvent &&
+          this.props.onStatusEvent(event.nativeEvent)
+        }
       />
     );
   }
@@ -120,7 +124,7 @@ BrightcovePlayer.propTypes = {
   onUpdateBufferProgress: PropTypes.func,
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
-  resizeAspectFill: PropTypes.bool
+  onStatusEvent: PropTypes.func,
 };
 
 BrightcovePlayer.defaultProps = {};


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/158605475
Paired with PR in crew_rn (https://github.com/TrueRowing/crew_rn/pull/242)
Design decisions:
 I added one single callback (onStatusEvent) rather than follow the existing pattern of one callback per event type.  11 new callbacks seemed too many and pointless.  I also added the new callback (onStatusEvent) to the existing events (i.e. onPlay() etc.).  This maintains backwards compatibility and allows callers to have a single event to track all status events.
I'm happy to discuss a different/better way. 

Also added a onStatusEvent() callback to loadMovie() since it was previously failing silently.

I tested the lifecycle events I could repro. I could not find a way to test the error returning events, such as kBCOVPlaybackSessionLifecycleEventFail which return error info in the event properties keyed by kBCOVPlaybackSessionLifecycleEventError. 

To test this, the easiest thing is to:
* in node_modules, delete react-native-brightcove-player
* Clone this repo/branch into that folder.
* debug in Xcode (for the the Objective-C)