### PR TITLE
Add seekToEnd for iOS live

### DIFF
--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -40,5 +40,6 @@
 @property (nonatomic, copy) RCTDirectEventBlock onID3Metadata;
 
 -(void) seekTo:(NSNumber *)time;
+-(void) seekToEnd;
 
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -135,6 +135,17 @@ BOOL _resizeAspectFill;
     _playerView.controlsView.hidden = disable;
 }
 
+- (void)seekToEnd {
+    if (_currentPlayer) {
+        CMTimeRange seekableRange = [_currentPlayer.currentItem.seekableTimeRanges.lastObject CMTimeRangeValue];
+        CGFloat seekableStart = CMTimeGetSeconds(seekableRange.start);
+        CGFloat seekableDuration = CMTimeGetSeconds(seekableRange.duration);
+        CGFloat livePosition = seekableStart + seekableDuration;
+        
+        [_currentPlayer seekToTime:CMTimeMake(livePosition, 1)];
+    }
+}
+
 - (void)seekTo:(NSNumber *)time {
     [_playbackController seekToTime:CMTimeMakeWithSeconds([time floatValue], NSEC_PER_SEC) completionHandler:^(BOOL finished) {
     }];
@@ -165,6 +176,7 @@ BOOL _resizeAspectFill;
     }
 
     if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventReady) {
+        _currentPlayer = session.player;
         if (self.onReady) {
             self.onReady(@{});
         }

--- a/ios/BrightcovePlayerManager.m
+++ b/ios/BrightcovePlayerManager.m
@@ -48,5 +48,14 @@ RCT_EXPORT_METHOD(seekTo:(nonnull NSNumber *)reactTag seconds:(nonnull NSNumber 
     }];
 }
 
+RCT_EXPORT_METHOD(seekToEnd:(nonnull NSNumber *)reactTag) {
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        BrightcovePlayer *player = (BrightcovePlayer*)viewRegistry[reactTag];
+        if ([player isKindOfClass:[BrightcovePlayer class]]) {
+            [player seekToEnd];
+        }
+    }];
+}
+
 
 @end

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -113,6 +113,18 @@ BrightcovePlayer.prototype.seekTo = Platform.select({
     }
 });
 
+BrightcovePlayer.prototype.seekToEnd = Platform.select({
+    ios: function () {
+        NativeModules.BrightcovePlayerManager.seekToEnd(
+            ReactNative.findNodeHandle(this)
+        );
+    },
+    android: function () {
+        // Not implemented for Android
+        return;
+    }
+});
+
 BrightcovePlayer.propTypes = {
     ...(ViewPropTypes || View.propTypes),
     policyKey: PropTypes.string,


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/161298691

For Live streams, add ability to seek-to-end (the current Live broadcast point)

**Testing notes**
* Start a live stream (real live stream)
* Setup the startTime so it's going to start within the next 15 minutes (or whatever duration_head is)
* On iOS start the workout.
* Note that the video behind the row to start is paused.
* Row to start (or press 'workout without stats') and observe that the video skips forward and is current.

**NOTE** I tested using OBS set to display a `window capture` with a webpage on: https://www.timeanddate.com/worldclock/timezone/utc
(this gave a small clock that is visible behind the Row to Start screen so you can see the time and know if it's skipping ahead.)