### PR TITLE
Fixing the "Map already consumed" exception

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -119,10 +119,8 @@ public class BrightcovePlayerView extends RelativeLayout {
             @Override
             public void processEvent(Event e) {
                 WritableMap event = Arguments.createMap();
-                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                        BrightcovePlayerManager.EVENT_READY, event);
                 event.putString("type", "ready");
+                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
                         BrightcovePlayerManager.EVENT_ONSTATUS, event);
             }
@@ -132,10 +130,8 @@ public class BrightcovePlayerView extends RelativeLayout {
             public void processEvent(Event e) {
                 BrightcovePlayerView.this.playing = true;
                 WritableMap event = Arguments.createMap();
-                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                        BrightcovePlayerManager.EVENT_PLAY, event);
                 event.putString("type", "play");
+                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
                         BrightcovePlayerManager.EVENT_ONSTATUS, event);
             }
@@ -145,24 +141,20 @@ public class BrightcovePlayerView extends RelativeLayout {
             public void processEvent(Event e) {
                 BrightcovePlayerView.this.playing = false;
                 WritableMap event = Arguments.createMap();
+                event.putString("type", "pause");
                 ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                        BrightcovePlayerManager.EVENT_PAUSE, event);
-                event.putString("type", "pause");
-                        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                                BrightcovePlayerManager.EVENT_ONSTATUS, event);
+                        BrightcovePlayerManager.EVENT_ONSTATUS, event);
             }
         });
         eventEmitter.on(EventType.COMPLETED, new EventListener() {
             @Override
             public void processEvent(Event e) {
                 WritableMap event = Arguments.createMap();
+                event.putString("type", "complete");
                 ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                        BrightcovePlayerManager.EVENT_END, event);
-                event.putString("type", "complete");
-                        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(),
-                                BrightcovePlayerManager.EVENT_ONSTATUS, event);
+                        BrightcovePlayerManager.EVENT_ONSTATUS, event);
             }
         });
         eventEmitter.on(EventType.PROGRESS, new EventListener() {


### PR DESCRIPTION
* Fixing the exception: "com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed"

```
10-19 17:31:45.256 18594-18594/com.truerowing.crew E/com.brightcove.player.event.EventEmitterImpl@305c780: processEvent() threw a throwable.
    com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
        at com.facebook.react.bridge.WritableNativeMap.putString(Native Method)
        at jp.manse.BrightcovePlayerView$5.processEvent(BrightcovePlayerView.java:138)
        at com.brightcove.player.event.EventEmitterImpl.invokeListenersForEventType(EventEmitterImpl.java:457)
        at com.brightcove.player.event.EventEmitterImpl.invokeListenersForEvent(EventEmitterImpl.java:428)
        at com.brightcove.player.event.EventEmitterImpl.access$300(EventEmitterImpl.java:41)
        at com.brightcove.player.event.EventEmitterImpl$1.handleMessage(EventEmitterImpl.java:73)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```