### PR TITLE
Release KVO when playback stops or on dealloc

### DIFF
--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -157,6 +157,12 @@ BOOL _resizeAspectFill;
         }
     }
 }
+- (void) removeKVOObserver {
+    if (_currentPlayer) {
+        [_currentPlayer.currentItem removeObserver:self forKeyPath:@"timedMetadata"];
+    }
+   
+}
 
 - (void)playbackController:(id<BCOVPlaybackController>)controller playbackSession:(id<BCOVPlaybackSession>)session didReceiveLifecycleEvent:(BCOVPlaybackSessionLifecycleEvent *)lifecycleEvent {
 
@@ -176,6 +182,7 @@ BOOL _resizeAspectFill;
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlay) {
         _playing = true;
 
+        [self removeKVOObserver];
         [session.player.currentItem addObserver:self forKeyPath:@"timedMetadata" options:NSKeyValueObservingOptionNew context:NULL];
 
         if (self.onPlay) {
@@ -197,6 +204,8 @@ BOOL _resizeAspectFill;
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventEnd) {
+        [self removeKVOObserver];
+        
         if (self.onEnd) {
             self.onEnd(@{});
         }
@@ -274,12 +283,14 @@ BOOL _resizeAspectFill;
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventTerminate) {
+        [self removeKVOObserver];
         if (self.onStatusEvent) {
             self.onStatusEvent(@{
                                  @"type": @("terminate")
                                  });
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventError) {
+        [self removeKVOObserver];
         if (self.onStatusEvent) {
             NSString* error = nil;
             if ([lifecycleEvent.properties  valueForKey:kBCOVPlaybackSessionEventKeyError] != nil ) {

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -18,6 +18,10 @@ BOOL _resizeAspectFill;
     return self;
 }
 
+- (void)dealloc {
+    [self removeKVOObserver];
+}
+
 - (void)setup {
     _playbackController = [BCOVPlayerSDKManager.sharedManager createPlaybackController];
     _playbackController.delegate = self;
@@ -159,6 +163,7 @@ BOOL _resizeAspectFill;
 }
 - (void) removeKVOObserver {
     if (_currentPlayer) {
+        NSLog(@"Brightcove removing KVOObserver");
         [_currentPlayer.currentItem removeObserver:self forKeyPath:@"timedMetadata"];
     }
    
@@ -183,6 +188,7 @@ BOOL _resizeAspectFill;
         _playing = true;
 
         [self removeKVOObserver];
+        _currentPlayer = session.player;
         [session.player.currentItem addObserver:self forKeyPath:@"timedMetadata" options:NSKeyValueObservingOptionNew context:NULL];
 
         if (self.onPlay) {
@@ -195,6 +201,7 @@ BOOL _resizeAspectFill;
         }
     } else if (lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPause) {
         _playing = false;
+         [self removeKVOObserver];
         if (self.onPause) {
             self.onPause(@{});
         }


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/161070344

Release KVO when playback stops or on dealloc.
Not able to repro.  Added code to release the observer when playback stops as a preventative measure.