### PR TITLE
Remove first buffering event- will track on client instead

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -59,7 +59,6 @@ public class BrightcovePlayerView extends RelativeLayout {
     private Catalog catalog;
     private boolean autoPlay = true;
     private boolean playing = false;
-    private boolean firstBuffering = true;
     private DefaultBandwidthMeter defaultBandwidthMeter;
     private ProgressBar progressBar;
 
@@ -162,7 +161,6 @@ public class BrightcovePlayerView extends RelativeLayout {
         eventEmitter.on(EventType.READY_TO_PLAY, new EventListener() {
             @Override
             public void processEvent(Event e) {
-                firstBuffering = true;
                 WritableMap event = Arguments.createMap();
                 ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
                 reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(), BrightcovePlayerManager.EVENT_READY, event);
@@ -295,12 +293,7 @@ public class BrightcovePlayerView extends RelativeLayout {
         eventEmitter.on(EventType.BUFFERING_COMPLETED, new EventListener() {
             @Override
             public void processEvent(Event e) {
-                if (firstBuffering){
-                    that.sendStatus("firstBufferingCompleted");
-                    firstBuffering = false;
-                } else {
-                    that.sendStatus("bufferingCompleted");
-                }
+                that.sendStatus("bufferingCompleted");
                 BrightcovePlayerView.this.progressBar.setVisibility(GONE);
             }
         });


### PR DESCRIPTION
In https://www.pivotaltracker.com/n/projects/2316398/stories/170559637, we found that the cause of workouts restarting in the middle of a workout was the 'firstBuferringCompleted' event got sent over multiple times through the video play. We get the READY_FOR_PLAY event several times throughout the video play time. We previously would reset the `firstBufferingCompleted` flag anytime we got that event in the react native brightcove player. That would cause the next buffer to send down a 'firstBufferingCompleted' event again, which would kick off a new workout in the middle of the existing one, resetting stats.

Instead, we will now just track the 'firstBufferingCompleted' as piece of state in WorkoutVideo.js. 

Corresponding crew_rn PR: https://github.com/TrueRowing/crew_rn/pull/2400